### PR TITLE
Add Vcs links to control file.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,6 +13,8 @@ Build-Depends: debhelper (>= 10),
     mce-dev
 Homepage: https://github.com/maemo-leste-extras/dorian
 XSBC-Bugtracker: https://github.com/maemo-leste-extras/dorian/issues
+Vcs-Git: https://github.com/maemo-leste-extras/dorian/
+Vcs-Browser: https://github.com/maemo-leste-extras/dorian/
 
 Package: dorian
 Architecture: any


### PR DESCRIPTION
Reuse Debian style links to version control system, to document where
to find the latest code for this package.