### PR TITLE
Drop obsolete Version and Installed-Size fields from d/control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -26,8 +26,6 @@ Depends: ${shlibs:Depends}, ${misc:Depends},
 Description: E-book reader
  Read books published in DRM-free EPUB format
 XB-Maemo-Display-Name: Dorian
-Version: 0.5.0
-Installed-Size: 9312
 XB-Maemo-Icon-26:
  iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAACXBIWXMAAAsT
  AAALEwEAmpwYAAABOWlDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjarZGx


### PR DESCRIPTION
The Version value should be fetched from d/changelog, and the
Installed-Size should be generated when the size of the built package
is known after building.