### PR TITLE
adopterwindow: support volume key scroll on non-N900 devices

### DIFF
--- a/adopterwindow.cpp
+++ b/adopterwindow.cpp
@@ -179,6 +179,7 @@ void AdopterWindow::keyPressEvent(QKeyEvent *event)
     case Qt::Key_PageDown:
 #ifdef Q_WS_MAEMO_5
     case Qt::Key_F7:
+    case Qt::Key_VolumeDown:
 #endif
         emit pageDown();
         event->accept();
@@ -186,6 +187,7 @@ void AdopterWindow::keyPressEvent(QKeyEvent *event)
     case Qt::Key_PageUp:
 #ifdef Q_WS_MAEMO_5
     case Qt::Key_F8:
+    case Qt::Key_VolumeUp:
 #endif
         emit pageUp();
         event->accept();


### PR DESCRIPTION
Under Fremantle, the volume keys were actually reported as F7 and F8. This is not the case for all other Leste devices, and nowadays even the Nokia N900 too. Support normal volume keys for the scrolling function.